### PR TITLE
Make gifs message collapsable

### DIFF
--- a/GifRocket.js
+++ b/GifRocket.js
@@ -44,6 +44,7 @@ class Script {
                 content: {
                     attachments: [
                         {
+                            title: "Gify",
                             image_url: gif,
                             color: ((config['color'] != '') ? '#' + config['color'].replace('#', '') : '#225159')
                         }


### PR DESCRIPTION
Adds title attribute in attachements for the message posted so that the
gif message is collapsable by users.

Resolves https://github.com/FinndropStudios/GifRocket/issues/11